### PR TITLE
feat: add offline todo planner with notifications

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -2,7 +2,8 @@
   "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
   "version": 1,
   "cli": {
-    "packageManager": "npm"
+    "packageManager": "npm",
+    "analytics": false
   },
   "newProjectRoot": "projects",
   "projects": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@angular/service-worker": "^20.3.0",
         "@angular/ssr": "^20.3.3",
         "express": "^5.1.0",
+        "idb": "^8.0.3",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0"
       },
@@ -6014,6 +6015,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/idb": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.3.tgz",
+      "integrity": "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==",
+      "license": "ISC"
     },
     "node_modules/ignore-walk": {
       "version": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@angular/service-worker": "^20.3.0",
     "@angular/ssr": "^20.3.3",
     "express": "^5.1.0",
+    "idb": "^8.0.3",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0"
   },

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,57 +1,20 @@
 {
-  "name": "pwa",
-  "short_name": "pwa",
+  "name": "Offline Todo Planner",
+  "short_name": "Todo Planner",
+  "description": "Track todos offline and receive reminders when tasks are added or updated.",
   "display": "standalone",
   "scope": "./",
   "start_url": "./",
+  "theme_color": "#1f3c88",
+  "background_color": "#10193a",
   "icons": [
-    {
-      "src": "icons/icon-72x72.png",
-      "sizes": "72x72",
-      "type": "image/png",
-      "purpose": "maskable any"
-    },
-    {
-      "src": "icons/icon-96x96.png",
-      "sizes": "96x96",
-      "type": "image/png",
-      "purpose": "maskable any"
-    },
-    {
-      "src": "icons/icon-128x128.png",
-      "sizes": "128x128",
-      "type": "image/png",
-      "purpose": "maskable any"
-    },
-    {
-      "src": "icons/icon-144x144.png",
-      "sizes": "144x144",
-      "type": "image/png",
-      "purpose": "maskable any"
-    },
-    {
-      "src": "icons/icon-152x152.png",
-      "sizes": "152x152",
-      "type": "image/png",
-      "purpose": "maskable any"
-    },
-    {
-      "src": "icons/icon-192x192.png",
-      "sizes": "192x192",
-      "type": "image/png",
-      "purpose": "maskable any"
-    },
-    {
-      "src": "icons/icon-384x384.png",
-      "sizes": "384x384",
-      "type": "image/png",
-      "purpose": "maskable any"
-    },
-    {
-      "src": "icons/icon-512x512.png",
-      "sizes": "512x512",
-      "type": "image/png",
-      "purpose": "maskable any"
-    }
+    { "src": "icons/icon-72x72.png", "sizes": "72x72", "type": "image/png", "purpose": "maskable any" },
+    { "src": "icons/icon-96x96.png", "sizes": "96x96", "type": "image/png", "purpose": "maskable any" },
+    { "src": "icons/icon-128x128.png", "sizes": "128x128", "type": "image/png", "purpose": "maskable any" },
+    { "src": "icons/icon-144x144.png", "sizes": "144x144", "type": "image/png", "purpose": "maskable any" },
+    { "src": "icons/icon-152x152.png", "sizes": "152x152", "type": "image/png", "purpose": "maskable any" },
+    { "src": "icons/icon-192x192.png", "sizes": "192x192", "type": "image/png", "purpose": "maskable any" },
+    { "src": "icons/icon-384x384.png", "sizes": "384x384", "type": "image/png", "purpose": "maskable any" },
+    { "src": "icons/icon-512x512.png", "sizes": "512x512", "type": "image/png", "purpose": "maskable any" }
   ]
 }

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,17 +1,24 @@
-import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZonelessChangeDetection, isDevMode } from '@angular/core';
+import {
+  ApplicationConfig,
+  isDevMode,
+  provideBrowserGlobalErrorListeners,
+  provideZonelessChangeDetection
+} from '@angular/core';
 import { provideRouter } from '@angular/router';
-
-import { routes } from './app.routes';
 import { provideClientHydration, withEventReplay } from '@angular/platform-browser';
 import { provideServiceWorker } from '@angular/service-worker';
+
+import { routes } from './app.routes';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideZonelessChangeDetection(),
-    provideRouter(routes), provideClientHydration(withEventReplay()), provideServiceWorker('ngsw-worker.js', {
-            enabled: !isDevMode(),
-            registrationStrategy: 'registerWhenStable:30000'
-          })
+    provideRouter(routes),
+    provideClientHydration(withEventReplay()),
+    provideServiceWorker('ngsw-worker.js', {
+      enabled: !isDevMode(),
+      registrationStrategy: 'registerWhenStable:30000'
+    })
   ]
 };

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -1,342 +1,72 @@
-<!-- * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * -->
-<!-- * * * * * * * * * * * The content below * * * * * * * * * * * -->
-<!-- * * * * * * * * * * is only a placeholder * * * * * * * * * * -->
-<!-- * * * * * * * * * * and can be replaced.  * * * * * * * * * * -->
-<!-- * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * -->
-<!-- * * * * * * * * * Delete the template below * * * * * * * * * -->
-<!-- * * * * * * * to get started with your project! * * * * * * * -->
-<!-- * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * -->
-
-<style>
-  :host {
-    --bright-blue: oklch(51.01% 0.274 263.83);
-    --electric-violet: oklch(53.18% 0.28 296.97);
-    --french-violet: oklch(47.66% 0.246 305.88);
-    --vivid-pink: oklch(69.02% 0.277 332.77);
-    --hot-red: oklch(61.42% 0.238 15.34);
-    --orange-red: oklch(63.32% 0.24 31.68);
-
-    --gray-900: oklch(19.37% 0.006 300.98);
-    --gray-700: oklch(36.98% 0.014 302.71);
-    --gray-400: oklch(70.9% 0.015 304.04);
-
-    --red-to-pink-to-purple-vertical-gradient: linear-gradient(
-      180deg,
-      var(--orange-red) 0%,
-      var(--vivid-pink) 50%,
-      var(--electric-violet) 100%
-    );
-
-    --red-to-pink-to-purple-horizontal-gradient: linear-gradient(
-      90deg,
-      var(--orange-red) 0%,
-      var(--vivid-pink) 50%,
-      var(--electric-violet) 100%
-    );
-
-    --pill-accent: var(--bright-blue);
-
-    font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-      Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
-      "Segoe UI Symbol";
-    box-sizing: border-box;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-  }
-
-  h1 {
-    font-size: 3.125rem;
-    color: var(--gray-900);
-    font-weight: 500;
-    line-height: 100%;
-    letter-spacing: -0.125rem;
-    margin: 0;
-    font-family: "Inter Tight", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-      Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
-      "Segoe UI Symbol";
-  }
-
-  p {
-    margin: 0;
-    color: var(--gray-700);
-  }
-
-  main {
-    width: 100%;
-    min-height: 100%;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    padding: 1rem;
-    box-sizing: inherit;
-    position: relative;
-  }
-
-  .angular-logo {
-    max-width: 9.2rem;
-  }
-
-  .content {
-    display: flex;
-    justify-content: space-around;
-    width: 100%;
-    max-width: 700px;
-    margin-bottom: 3rem;
-  }
-
-  .content h1 {
-    margin-top: 1.75rem;
-  }
-
-  .content p {
-    margin-top: 1.5rem;
-  }
-
-  .divider {
-    width: 1px;
-    background: var(--red-to-pink-to-purple-vertical-gradient);
-    margin-inline: 0.5rem;
-  }
-
-  .pill-group {
-    display: flex;
-    flex-direction: column;
-    align-items: start;
-    flex-wrap: wrap;
-    gap: 1.25rem;
-  }
-
-  .pill {
-    display: flex;
-    align-items: center;
-    --pill-accent: var(--bright-blue);
-    background: color-mix(in srgb, var(--pill-accent) 5%, transparent);
-    color: var(--pill-accent);
-    padding-inline: 0.75rem;
-    padding-block: 0.375rem;
-    border-radius: 2.75rem;
-    border: 0;
-    transition: background 0.3s ease;
-    font-family: var(--inter-font);
-    font-size: 0.875rem;
-    font-style: normal;
-    font-weight: 500;
-    line-height: 1.4rem;
-    letter-spacing: -0.00875rem;
-    text-decoration: none;
-    white-space: nowrap;
-  }
-
-  .pill:hover {
-    background: color-mix(in srgb, var(--pill-accent) 15%, transparent);
-  }
-
-  .pill-group .pill:nth-child(6n + 1) {
-    --pill-accent: var(--bright-blue);
-  }
-  .pill-group .pill:nth-child(6n + 2) {
-    --pill-accent: var(--electric-violet);
-  }
-  .pill-group .pill:nth-child(6n + 3) {
-    --pill-accent: var(--french-violet);
-  }
-
-  .pill-group .pill:nth-child(6n + 4),
-  .pill-group .pill:nth-child(6n + 5),
-  .pill-group .pill:nth-child(6n + 6) {
-    --pill-accent: var(--hot-red);
-  }
-
-  .pill-group svg {
-    margin-inline-start: 0.25rem;
-  }
-
-  .social-links {
-    display: flex;
-    align-items: center;
-    gap: 0.73rem;
-    margin-top: 1.5rem;
-  }
-
-  .social-links path {
-    transition: fill 0.3s ease;
-    fill: var(--gray-400);
-  }
-
-  .social-links a:hover svg path {
-    fill: var(--gray-900);
-  }
-
-  @media screen and (max-width: 650px) {
-    .content {
-      flex-direction: column;
-      width: max-content;
-    }
-
-    .divider {
-      height: 1px;
-      width: 100%;
-      background: var(--red-to-pink-to-purple-horizontal-gradient);
-      margin-block: 1.5rem;
-    }
-  }
-</style>
-
-<main class="main">
-  <div class="content">
-    <div class="left-side">
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 982 239"
-        fill="none"
-        class="angular-logo"
-      >
-        <g clip-path="url(#a)">
-          <path
-            fill="url(#b)"
-            d="M388.676 191.625h30.849L363.31 31.828h-35.758l-56.215 159.797h30.848l13.174-39.356h60.061l13.256 39.356Zm-65.461-62.675 21.602-64.311h1.227l21.602 64.311h-44.431Zm126.831-7.527v70.202h-28.23V71.839h27.002v20.374h1.392c2.782-6.71 7.2-12.028 13.255-15.956 6.056-3.927 13.584-5.89 22.503-5.89 8.264 0 15.465 1.8 21.684 5.318 6.137 3.518 10.964 8.673 14.319 15.382 3.437 6.71 5.074 14.81 4.992 24.383v76.175h-28.23v-71.92c0-8.019-2.046-14.237-6.219-18.819-4.173-4.5-9.819-6.791-17.102-6.791-4.91 0-9.328 1.063-13.174 3.272-3.846 2.128-6.792 5.237-9.001 9.328-2.046 4.009-3.191 8.918-3.191 14.728ZM589.233 239c-10.147 0-18.82-1.391-26.103-4.091-7.282-2.7-13.092-6.382-17.511-10.964-4.418-4.582-7.528-9.655-9.164-15.219l25.448-6.136c1.145 2.372 2.782 4.663 4.991 6.954 2.209 2.291 5.155 4.255 8.837 5.81 3.683 1.554 8.428 2.291 14.074 2.291 8.019 0 14.647-1.964 19.884-5.81 5.237-3.845 7.856-10.227 7.856-19.064v-22.665h-1.391c-1.473 2.946-3.601 5.892-6.383 9.001-2.782 3.109-6.464 5.645-10.965 7.691-4.582 2.046-10.228 3.109-17.101 3.109-9.165 0-17.511-2.209-25.039-6.545-7.446-4.337-13.42-10.883-17.757-19.474-4.418-8.673-6.628-19.473-6.628-32.565 0-13.091 2.21-24.301 6.628-33.383 4.419-9.082 10.311-15.955 17.839-20.7 7.528-4.746 15.874-7.037 25.039-7.037 7.037 0 12.846 1.145 17.347 3.518 4.582 2.373 8.182 5.236 10.883 8.51 2.7 3.272 4.746 6.382 6.137 9.327h1.554v-19.8h27.821v121.749c0 10.228-2.454 18.737-7.364 25.447-4.91 6.709-11.538 11.7-20.048 15.055-8.509 3.355-18.165 4.991-28.884 4.991Zm.245-71.266c5.974 0 11.047-1.473 15.302-4.337 4.173-2.945 7.446-7.118 9.573-12.519 2.21-5.482 3.274-12.027 3.274-19.637 0-7.609-1.064-14.155-3.274-19.8-2.127-5.646-5.318-10.064-9.491-13.255-4.174-3.11-9.329-4.746-15.384-4.746s-11.537 1.636-15.792 4.91c-4.173 3.272-7.365 7.772-9.492 13.418-2.128 5.727-3.191 12.191-3.191 19.392 0 7.2 1.063 13.745 3.273 19.228 2.127 5.482 5.318 9.736 9.573 12.764 4.174 3.027 9.41 4.582 15.629 4.582Zm141.56-26.51V71.839h28.23v119.786h-27.412v-21.273h-1.227c-2.7 6.709-7.119 12.191-13.338 16.446-6.137 4.255-13.747 6.382-22.748 6.382-7.855 0-14.81-1.718-20.783-5.237-5.974-3.518-10.72-8.591-14.075-15.382-3.355-6.709-5.073-14.891-5.073-24.464V71.839h28.312v71.921c0 7.609 2.046 13.664 6.219 18.083 4.173 4.5 9.655 6.709 16.365 6.709 4.173 0 8.183-.982 12.111-3.028 3.927-2.045 7.118-5.072 9.655-9.082 2.537-4.091 3.764-9.164 3.764-15.218Zm65.707-109.395v159.796h-28.23V31.828h28.23Zm44.841 162.169c-7.61 0-14.402-1.391-20.457-4.091-6.055-2.7-10.883-6.791-14.32-12.109-3.518-5.319-5.237-11.946-5.237-19.801 0-6.791 1.228-12.355 3.765-16.773 2.536-4.419 5.891-7.937 10.228-10.637 4.337-2.618 9.164-4.664 14.647-6.055 5.4-1.391 11.046-2.373 16.856-3.027 7.037-.737 12.683-1.391 17.102-1.964 4.337-.573 7.528-1.555 9.574-2.782 1.963-1.309 3.027-3.273 3.027-5.973v-.491c0-5.891-1.718-10.391-5.237-13.664-3.518-3.191-8.51-4.828-15.056-4.828-6.955 0-12.356 1.473-16.447 4.5-4.009 3.028-6.71 6.546-8.183 10.719l-26.348-3.764c2.046-7.282 5.483-13.336 10.31-18.328 4.746-4.909 10.638-8.59 17.511-11.045 6.955-2.455 14.565-3.682 22.912-3.682 5.809 0 11.537.654 17.265 2.045s10.965 3.6 15.711 6.71c4.746 3.109 8.51 7.282 11.455 12.6 2.864 5.318 4.337 11.946 4.337 19.883v80.184h-27.166v-16.446h-.9c-1.719 3.355-4.092 6.464-7.201 9.328-3.109 2.864-6.955 5.237-11.619 6.955-4.828 1.718-10.229 2.536-16.529 2.536Zm7.364-20.701c5.646 0 10.556-1.145 14.729-3.354 4.173-2.291 7.364-5.237 9.655-9.001 2.292-3.763 3.355-7.854 3.355-12.273v-14.155c-.9.737-2.373 1.391-4.5 2.046-2.128.654-4.419 1.145-7.037 1.636-2.619.491-5.155.9-7.692 1.227-2.537.328-4.746.655-6.628.901-4.173.572-8.019 1.472-11.292 2.781-3.355 1.31-5.973 3.11-7.855 5.401-1.964 2.291-2.864 5.318-2.864 8.918 0 5.237 1.882 9.164 5.728 11.782 3.682 2.782 8.51 4.091 14.401 4.091Zm64.643 18.328V71.839h27.412v19.965h1.227c2.21-6.955 5.974-12.274 11.292-16.038 5.319-3.763 11.456-5.645 18.329-5.645 1.555 0 3.355.082 5.237.163 1.964.164 3.601.328 4.91.573v25.938c-1.227-.41-3.109-.819-5.646-1.146a58.814 58.814 0 0 0-7.446-.49c-5.155 0-9.738 1.145-13.829 3.354-4.091 2.209-7.282 5.236-9.655 9.164-2.373 3.927-3.519 8.427-3.519 13.5v70.448h-28.312ZM222.077 39.192l-8.019 125.923L137.387 0l84.69 39.192Zm-53.105 162.825-57.933 33.056-57.934-33.056 11.783-28.556h92.301l11.783 28.556ZM111.039 62.675l30.357 73.803H80.681l30.358-73.803ZM7.937 165.115 0 39.192 84.69 0 7.937 165.115Z"
-          />
-          <path
-            fill="url(#c)"
-            d="M388.676 191.625h30.849L363.31 31.828h-35.758l-56.215 159.797h30.848l13.174-39.356h60.061l13.256 39.356Zm-65.461-62.675 21.602-64.311h1.227l21.602 64.311h-44.431Zm126.831-7.527v70.202h-28.23V71.839h27.002v20.374h1.392c2.782-6.71 7.2-12.028 13.255-15.956 6.056-3.927 13.584-5.89 22.503-5.89 8.264 0 15.465 1.8 21.684 5.318 6.137 3.518 10.964 8.673 14.319 15.382 3.437 6.71 5.074 14.81 4.992 24.383v76.175h-28.23v-71.92c0-8.019-2.046-14.237-6.219-18.819-4.173-4.5-9.819-6.791-17.102-6.791-4.91 0-9.328 1.063-13.174 3.272-3.846 2.128-6.792 5.237-9.001 9.328-2.046 4.009-3.191 8.918-3.191 14.728ZM589.233 239c-10.147 0-18.82-1.391-26.103-4.091-7.282-2.7-13.092-6.382-17.511-10.964-4.418-4.582-7.528-9.655-9.164-15.219l25.448-6.136c1.145 2.372 2.782 4.663 4.991 6.954 2.209 2.291 5.155 4.255 8.837 5.81 3.683 1.554 8.428 2.291 14.074 2.291 8.019 0 14.647-1.964 19.884-5.81 5.237-3.845 7.856-10.227 7.856-19.064v-22.665h-1.391c-1.473 2.946-3.601 5.892-6.383 9.001-2.782 3.109-6.464 5.645-10.965 7.691-4.582 2.046-10.228 3.109-17.101 3.109-9.165 0-17.511-2.209-25.039-6.545-7.446-4.337-13.42-10.883-17.757-19.474-4.418-8.673-6.628-19.473-6.628-32.565 0-13.091 2.21-24.301 6.628-33.383 4.419-9.082 10.311-15.955 17.839-20.7 7.528-4.746 15.874-7.037 25.039-7.037 7.037 0 12.846 1.145 17.347 3.518 4.582 2.373 8.182 5.236 10.883 8.51 2.7 3.272 4.746 6.382 6.137 9.327h1.554v-19.8h27.821v121.749c0 10.228-2.454 18.737-7.364 25.447-4.91 6.709-11.538 11.7-20.048 15.055-8.509 3.355-18.165 4.991-28.884 4.991Zm.245-71.266c5.974 0 11.047-1.473 15.302-4.337 4.173-2.945 7.446-7.118 9.573-12.519 2.21-5.482 3.274-12.027 3.274-19.637 0-7.609-1.064-14.155-3.274-19.8-2.127-5.646-5.318-10.064-9.491-13.255-4.174-3.11-9.329-4.746-15.384-4.746s-11.537 1.636-15.792 4.91c-4.173 3.272-7.365 7.772-9.492 13.418-2.128 5.727-3.191 12.191-3.191 19.392 0 7.2 1.063 13.745 3.273 19.228 2.127 5.482 5.318 9.736 9.573 12.764 4.174 3.027 9.41 4.582 15.629 4.582Zm141.56-26.51V71.839h28.23v119.786h-27.412v-21.273h-1.227c-2.7 6.709-7.119 12.191-13.338 16.446-6.137 4.255-13.747 6.382-22.748 6.382-7.855 0-14.81-1.718-20.783-5.237-5.974-3.518-10.72-8.591-14.075-15.382-3.355-6.709-5.073-14.891-5.073-24.464V71.839h28.312v71.921c0 7.609 2.046 13.664 6.219 18.083 4.173 4.5 9.655 6.709 16.365 6.709 4.173 0 8.183-.982 12.111-3.028 3.927-2.045 7.118-5.072 9.655-9.082 2.537-4.091 3.764-9.164 3.764-15.218Zm65.707-109.395v159.796h-28.23V31.828h28.23Zm44.841 162.169c-7.61 0-14.402-1.391-20.457-4.091-6.055-2.7-10.883-6.791-14.32-12.109-3.518-5.319-5.237-11.946-5.237-19.801 0-6.791 1.228-12.355 3.765-16.773 2.536-4.419 5.891-7.937 10.228-10.637 4.337-2.618 9.164-4.664 14.647-6.055 5.4-1.391 11.046-2.373 16.856-3.027 7.037-.737 12.683-1.391 17.102-1.964 4.337-.573 7.528-1.555 9.574-2.782 1.963-1.309 3.027-3.273 3.027-5.973v-.491c0-5.891-1.718-10.391-5.237-13.664-3.518-3.191-8.51-4.828-15.056-4.828-6.955 0-12.356 1.473-16.447 4.5-4.009 3.028-6.71 6.546-8.183 10.719l-26.348-3.764c2.046-7.282 5.483-13.336 10.31-18.328 4.746-4.909 10.638-8.59 17.511-11.045 6.955-2.455 14.565-3.682 22.912-3.682 5.809 0 11.537.654 17.265 2.045s10.965 3.6 15.711 6.71c4.746 3.109 8.51 7.282 11.455 12.6 2.864 5.318 4.337 11.946 4.337 19.883v80.184h-27.166v-16.446h-.9c-1.719 3.355-4.092 6.464-7.201 9.328-3.109 2.864-6.955 5.237-11.619 6.955-4.828 1.718-10.229 2.536-16.529 2.536Zm7.364-20.701c5.646 0 10.556-1.145 14.729-3.354 4.173-2.291 7.364-5.237 9.655-9.001 2.292-3.763 3.355-7.854 3.355-12.273v-14.155c-.9.737-2.373 1.391-4.5 2.046-2.128.654-4.419 1.145-7.037 1.636-2.619.491-5.155.9-7.692 1.227-2.537.328-4.746.655-6.628.901-4.173.572-8.019 1.472-11.292 2.781-3.355 1.31-5.973 3.11-7.855 5.401-1.964 2.291-2.864 5.318-2.864 8.918 0 5.237 1.882 9.164 5.728 11.782 3.682 2.782 8.51 4.091 14.401 4.091Zm64.643 18.328V71.839h27.412v19.965h1.227c2.21-6.955 5.974-12.274 11.292-16.038 5.319-3.763 11.456-5.645 18.329-5.645 1.555 0 3.355.082 5.237.163 1.964.164 3.601.328 4.91.573v25.938c-1.227-.41-3.109-.819-5.646-1.146a58.814 58.814 0 0 0-7.446-.49c-5.155 0-9.738 1.145-13.829 3.354-4.091 2.209-7.282 5.236-9.655 9.164-2.373 3.927-3.519 8.427-3.519 13.5v70.448h-28.312ZM222.077 39.192l-8.019 125.923L137.387 0l84.69 39.192Zm-53.105 162.825-57.933 33.056-57.934-33.056 11.783-28.556h92.301l11.783 28.556ZM111.039 62.675l30.357 73.803H80.681l30.358-73.803ZM7.937 165.115 0 39.192 84.69 0 7.937 165.115Z"
-          />
-        </g>
-        <defs>
-          <radialGradient
-            id="c"
-            cx="0"
-            cy="0"
-            r="1"
-            gradientTransform="rotate(118.122 171.182 60.81) scale(205.794)"
-            gradientUnits="userSpaceOnUse"
-          >
-            <stop stop-color="#FF41F8" />
-            <stop offset=".707" stop-color="#FF41F8" stop-opacity=".5" />
-            <stop offset="1" stop-color="#FF41F8" stop-opacity="0" />
-          </radialGradient>
-          <linearGradient
-            id="b"
-            x1="0"
-            x2="982"
-            y1="192"
-            y2="192"
-            gradientUnits="userSpaceOnUse"
-          >
-            <stop stop-color="#F0060B" />
-            <stop offset="0" stop-color="#F0070C" />
-            <stop offset=".526" stop-color="#CC26D5" />
-            <stop offset="1" stop-color="#7702FF" />
-          </linearGradient>
-          <clipPath id="a"><path fill="#fff" d="M0 0h982v239H0z" /></clipPath>
-        </defs>
-      </svg>
-      <h1>Hello, {{ title() }}</h1>
-      <p>Congratulations! Your app is running. 🎉</p>
-    </div>
-    <div class="divider" role="separator" aria-label="Divider"></div>
-    <div class="right-side">
-      <div class="pill-group">
-        @for (item of [
-          { title: 'Explore the Docs', link: 'https://angular.dev' },
-          { title: 'Learn with Tutorials', link: 'https://angular.dev/tutorials' },
-          { title: 'Prompt and best practices for AI', link: 'https://angular.dev/ai/develop-with-ai'},
-          { title: 'CLI Docs', link: 'https://angular.dev/tools/cli' },
-          { title: 'Angular Language Service', link: 'https://angular.dev/tools/language-service' },
-          { title: 'Angular DevTools', link: 'https://angular.dev/tools/devtools' },
-        ]; track item.title) {
-          <a
-            class="pill"
-            [href]="item.link"
-            target="_blank"
-            rel="noopener"
-          >
-            <span>{{ item.title }}</span>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              height="14"
-              viewBox="0 -960 960 960"
-              width="14"
-              fill="currentColor"
-            >
-              <path
-                d="M200-120q-33 0-56.5-23.5T120-200v-560q0-33 23.5-56.5T200-840h280v80H200v560h560v-280h80v280q0 33-23.5 56.5T760-120H200Zm188-212-56-56 372-372H560v-80h280v280h-80v-144L388-332Z"
-              />
-            </svg>
-          </a>
-        }
+<main class="app-shell">
+  <section class="todo-card">
+    <header class="todo-header">
+      <div>
+        <h1>Offline Todo Planner</h1>
+        <p>Manage your tasks anywhere. Changes sync when you are back online.</p>
       </div>
-      <div class="social-links">
-        <a
-          href="https://github.com/angular/angular"
-          aria-label="Github"
-          target="_blank"
-          rel="noopener"
-        >
-          <svg
-            width="25"
-            height="24"
-            viewBox="0 0 25 24"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-            alt="Github"
-          >
-            <path
-              d="M12.3047 0C5.50634 0 0 5.50942 0 12.3047C0 17.7423 3.52529 22.3535 8.41332 23.9787C9.02856 24.0946 9.25414 23.7142 9.25414 23.3871C9.25414 23.0949 9.24389 22.3207 9.23876 21.2953C5.81601 22.0377 5.09414 19.6444 5.09414 19.6444C4.53427 18.2243 3.72524 17.8449 3.72524 17.8449C2.61064 17.082 3.81137 17.0973 3.81137 17.0973C5.04697 17.1835 5.69604 18.3647 5.69604 18.3647C6.79321 20.2463 8.57636 19.7029 9.27978 19.3881C9.39052 18.5924 9.70736 18.0499 10.0591 17.7423C7.32641 17.4347 4.45429 16.3765 4.45429 11.6618C4.45429 10.3185 4.9311 9.22133 5.72065 8.36C5.58222 8.04931 5.16694 6.79833 5.82831 5.10337C5.82831 5.10337 6.85883 4.77319 9.2121 6.36459C10.1965 6.09082 11.2424 5.95546 12.2883 5.94931C13.3342 5.95546 14.3801 6.09082 15.3644 6.36459C17.7023 4.77319 18.7328 5.10337 18.7328 5.10337C19.3942 6.79833 18.9789 8.04931 18.8559 8.36C19.6403 9.22133 20.1171 10.3185 20.1171 11.6618C20.1171 16.3888 17.2409 17.4296 14.5031 17.7321C14.9338 18.1012 15.3337 18.8559 15.3337 20.0084C15.3337 21.6552 15.3183 22.978 15.3183 23.3779C15.3183 23.7009 15.5336 24.0854 16.1642 23.9623C21.0871 22.3484 24.6094 17.7341 24.6094 12.3047C24.6094 5.50942 19.0999 0 12.3047 0Z"
-            />
-          </svg>
-        </a>
-        <a
-          href="https://twitter.com/angular"
-          aria-label="Twitter"
-          target="_blank"
-          rel="noopener"
-        >
-          <svg
-            width="24"
-            height="24"
-            viewBox="0 0 24 24"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-            alt="Twitter"
-          >
-            <path
-              d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"
-            />
-          </svg>
-        </a>
-        <a
-          href="https://www.youtube.com/channel/UCbn1OgGei-DV7aSRo_HaAiw"
-          aria-label="Youtube"
-          target="_blank"
-          rel="noopener"
-        >
-          <svg
-            width="29"
-            height="20"
-            viewBox="0 0 29 20"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-            alt="Youtube"
-          >
-            <path
-              fill-rule="evenodd"
-              clip-rule="evenodd"
-              d="M27.4896 1.52422C27.9301 1.96749 28.2463 2.51866 28.4068 3.12258C29.0004 5.35161 29.0004 10 29.0004 10C29.0004 10 29.0004 14.6484 28.4068 16.8774C28.2463 17.4813 27.9301 18.0325 27.4896 18.4758C27.0492 18.9191 26.5 19.2389 25.8972 19.4032C23.6778 20 14.8068 20 14.8068 20C14.8068 20 5.93586 20 3.71651 19.4032C3.11363 19.2389 2.56449 18.9191 2.12405 18.4758C1.68361 18.0325 1.36732 17.4813 1.20683 16.8774C0.613281 14.6484 0.613281 10 0.613281 10C0.613281 10 0.613281 5.35161 1.20683 3.12258C1.36732 2.51866 1.68361 1.96749 2.12405 1.52422C2.56449 1.08095 3.11363 0.76113 3.71651 0.596774C5.93586 0 14.8068 0 14.8068 0C14.8068 0 23.6778 0 25.8972 0.596774C26.5 0.76113 27.0492 1.08095 27.4896 1.52422ZM19.3229 10L11.9036 5.77905V14.221L19.3229 10Z"
-            />
-          </svg>
-        </a>
+      <div class="status-indicator" [class.offline]="!isOnline()">
+        <span class="dot"></span>
+        <span>{{ isOnline() ? 'Online' : 'Offline' }}</span>
       </div>
-    </div>
-  </div>
+    </header>
+
+    <section class="actions">
+      <button type="button" class="secondary" (click)="enableNotifications()">
+        Enable notifications
+      </button>
+      <div class="pending" *ngIf="todos().length > 0">
+        {{ pendingCount() }} pending
+      </div>
+    </section>
+
+    <form class="todo-form" [formGroup]="todoForm" (ngSubmit)="createTodo()" novalidate>
+      <input
+        type="text"
+        formControlName="title"
+        placeholder="Add a task and press enter"
+        autocomplete="off"
+        required
+      />
+      <button type="submit" [disabled]="todoForm.invalid">Add</button>
+    </form>
+
+    <section *ngIf="todos().length > 0; else emptyState" class="todo-list">
+      <article *ngFor="let todo of todos(); trackBy: trackByTodo" [class.completed]="todo.completed">
+        <div class="todo-content" *ngIf="editingId() !== todo.id; else editMode">
+          <label class="todo-title">
+            <input
+              type="checkbox"
+              [checked]="todo.completed"
+              (change)="onToggleChange(todo.id, $event)"
+              aria-label="Toggle {{ todo.title }}"
+            />
+            <span>{{ todo.title }}</span>
+          </label>
+          <p class="meta">Updated {{ todo.updatedAt | date: 'medium' }}</p>
+        </div>
+
+        <ng-template #editMode>
+          <form class="edit-form" (ngSubmit)="commitEdit(todo.id)">
+            <input type="text" [formControl]="editControl" required />
+            <div class="edit-actions">
+              <button type="submit" [disabled]="editControl.invalid">Save</button>
+              <button type="button" class="secondary" (click)="cancelEdit()">Cancel</button>
+            </div>
+          </form>
+        </ng-template>
+
+        <div class="todo-actions" *ngIf="editingId() !== todo.id">
+          <button type="button" class="secondary" (click)="beginEdit(todo)">Edit</button>
+          <button type="button" class="danger" (click)="removeTodo(todo.id)">Delete</button>
+        </div>
+      </article>
+    </section>
+
+    <ng-template #emptyState>
+      <div class="empty-state">
+        <p>Your todo list is empty. Start by adding the first task above.</p>
+      </div>
+    </ng-template>
+  </section>
 </main>
-
-<!-- * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * -->
-<!-- * * * * * * * * * * * The content above * * * * * * * * * * * * -->
-<!-- * * * * * * * * * * is only a placeholder * * * * * * * * * * * -->
-<!-- * * * * * * * * * * and can be replaced.  * * * * * * * * * * * -->
-<!-- * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * -->
-<!-- * * * * * * * * * * End of Placeholder  * * * * * * * * * * * * -->
-<!-- * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * -->
-
-
-<router-outlet />

--- a/src/app/app.scss
+++ b/src/app/app.scss
@@ -1,0 +1,260 @@
+:host {
+  display: block;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, #1f3c88, #10193a 60%);
+  color: #f4f6fb;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  padding: 2rem 1rem 4rem;
+  box-sizing: border-box;
+}
+
+.app-shell {
+  display: flex;
+  justify-content: center;
+}
+
+.todo-card {
+  width: min(720px, 100%);
+  background: rgba(17, 24, 39, 0.85);
+  backdrop-filter: blur(12px);
+  border-radius: 24px;
+  padding: 2.5rem 2rem;
+  box-shadow: 0 25px 45px rgba(15, 23, 42, 0.4);
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.todo-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1.5rem;
+
+  h1 {
+    font-size: clamp(2rem, 3vw + 1rem, 2.75rem);
+    margin: 0 0 0.5rem;
+  }
+
+  p {
+    margin: 0;
+    color: rgba(226, 232, 240, 0.7);
+  }
+}
+
+.status-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(34, 197, 94, 0.15);
+  color: #a7f3d0;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+
+  &.offline {
+    background: rgba(248, 113, 113, 0.18);
+    color: #fecaca;
+
+    .dot {
+      background: #ef4444;
+    }
+  }
+
+  .dot {
+    width: 0.65rem;
+    height: 0.65rem;
+    border-radius: 50%;
+    background: #22c55e;
+  }
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+
+  .pending {
+    font-weight: 600;
+    color: rgba(196, 181, 253, 0.9);
+  }
+}
+
+button {
+  cursor: pointer;
+  border: none;
+  border-radius: 999px;
+  padding: 0.75rem 1.5rem;
+  font-weight: 600;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, opacity 0.2s ease;
+  background: linear-gradient(135deg, #6366f1, #ec4899);
+  color: #f8fafc;
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+
+  &:hover:not(:disabled) {
+    transform: translateY(-1px);
+    box-shadow: 0 12px 24px rgba(99, 102, 241, 0.35);
+  }
+
+  &.secondary {
+    background: transparent;
+    color: rgba(226, 232, 240, 0.85);
+    border: 1px solid rgba(148, 163, 184, 0.4);
+    padding-inline: 1.25rem;
+
+    &:hover {
+      box-shadow: none;
+      background: rgba(148, 163, 184, 0.1);
+    }
+  }
+
+  &.danger {
+    background: rgba(248, 113, 113, 0.15);
+    color: #fecaca;
+    border: 1px solid rgba(248, 113, 113, 0.35);
+
+    &:hover {
+      box-shadow: none;
+      background: rgba(248, 113, 113, 0.3);
+    }
+  }
+}
+
+.todo-form {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 1rem;
+
+  input {
+    padding: 0.85rem 1.15rem;
+    border-radius: 16px;
+    border: 1px solid rgba(148, 163, 184, 0.4);
+    background: rgba(15, 23, 42, 0.75);
+    color: #f8fafc;
+    font-size: 1rem;
+
+    &::placeholder {
+      color: rgba(148, 163, 184, 0.6);
+    }
+
+    &:focus {
+      outline: none;
+      border-color: rgba(129, 140, 248, 0.8);
+      box-shadow: 0 0 0 3px rgba(129, 140, 248, 0.2);
+    }
+  }
+}
+
+.todo-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+
+  article {
+    background: rgba(30, 41, 59, 0.8);
+    border-radius: 20px;
+    padding: 1.25rem 1.5rem;
+    display: grid;
+    gap: 0.75rem;
+    border: 1px solid transparent;
+    transition: border-color 0.2s ease;
+
+    &.completed {
+      border-color: rgba(34, 197, 94, 0.35);
+
+      .todo-title span {
+        text-decoration: line-through;
+        color: rgba(148, 163, 184, 0.75);
+      }
+    }
+  }
+}
+
+.todo-content {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+
+  .todo-title {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    font-size: 1.05rem;
+
+    input[type='checkbox'] {
+      width: 1.1rem;
+      height: 1.1rem;
+      accent-color: #8b5cf6;
+    }
+  }
+
+  .meta {
+    margin: 0;
+    color: rgba(148, 163, 184, 0.7);
+    font-size: 0.85rem;
+  }
+}
+
+.todo-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.edit-form {
+  display: grid;
+  gap: 0.75rem;
+
+  input {
+    padding: 0.75rem 1rem;
+    border-radius: 14px;
+    border: 1px solid rgba(129, 140, 248, 0.4);
+    background: rgba(15, 23, 42, 0.65);
+    color: #f8fafc;
+
+    &:focus {
+      outline: none;
+      border-color: rgba(196, 181, 253, 0.9);
+      box-shadow: 0 0 0 3px rgba(167, 139, 250, 0.25);
+    }
+  }
+
+  .edit-actions {
+    display: flex;
+    gap: 0.75rem;
+    justify-content: flex-end;
+  }
+}
+
+.empty-state {
+  text-align: center;
+  padding: 2rem;
+  border-radius: 16px;
+  background: rgba(30, 41, 59, 0.6);
+  border: 1px dashed rgba(148, 163, 184, 0.4);
+  color: rgba(226, 232, 240, 0.8);
+}
+
+@media (max-width: 600px) {
+  .todo-form {
+    grid-template-columns: 1fr;
+  }
+
+  .todo-content {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .todo-actions {
+    flex-wrap: wrap;
+  }
+}

--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -20,6 +20,6 @@ describe('App', () => {
     const fixture = TestBed.createComponent(App);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, pwa');
+    expect(compiled.querySelector('h1')?.textContent).toContain('Offline Todo Planner');
   });
 });

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,12 +1,87 @@
-import { Component, signal } from '@angular/core';
-import { RouterOutlet } from '@angular/router';
+import { Component, computed, inject, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, Validators, NonNullableFormBuilder } from '@angular/forms';
+import { DatePipe } from '@angular/common';
+import { TodoService } from './services/todo.service';
+import { ConnectivityService } from './services/connectivity.service';
+import { NotificationService } from './services/notification.service';
+import { Todo } from './models/todo';
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet],
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, DatePipe],
   templateUrl: './app.html',
   styleUrl: './app.scss'
 })
 export class App {
-  protected readonly title = signal('pwa');
+  private readonly formBuilder = inject(NonNullableFormBuilder);
+  private readonly todoService = inject(TodoService);
+  private readonly connectivityService = inject(ConnectivityService);
+  private readonly notificationService = inject(NotificationService);
+
+  protected readonly todos = this.todoService.all;
+  protected readonly isOnline = this.connectivityService.isOnline;
+  protected readonly editingId = signal<string | null>(null);
+
+  protected readonly todoForm = this.formBuilder.group({
+    title: ['', [Validators.required, Validators.maxLength(120)]]
+  });
+
+  protected readonly editControl = this.formBuilder.control('', {
+    validators: [Validators.required, Validators.maxLength(120)]
+  });
+
+  protected readonly pendingCount = computed(
+    () => this.todos().filter((todo) => !todo.completed).length
+  );
+
+  createTodo(): void {
+    if (this.todoForm.invalid) {
+      return;
+    }
+
+    const { title } = this.todoForm.getRawValue();
+    this.todoService.addTodo(title);
+    this.todoForm.reset({ title: '' });
+  }
+
+  beginEdit(todo: Todo): void {
+    this.editingId.set(todo.id);
+    this.editControl.setValue(todo.title);
+  }
+
+  commitEdit(id: string): void {
+    if (this.editControl.invalid) {
+      return;
+    }
+
+    this.todoService.updateTodoTitle(id, this.editControl.getRawValue());
+    this.editingId.set(null);
+    this.editControl.reset('');
+  }
+
+  cancelEdit(): void {
+    this.editingId.set(null);
+    this.editControl.reset('');
+  }
+
+  toggleTodo(id: string, completed: boolean): void {
+    this.todoService.toggleTodo(id, completed);
+  }
+
+  onToggleChange(id: string, event: Event): void {
+    const target = event.target as HTMLInputElement | null;
+    this.toggleTodo(id, !!target?.checked);
+  }
+
+  removeTodo(id: string): void {
+    this.todoService.removeTodo(id);
+  }
+
+  trackByTodo = this.todoService.trackById.bind(this.todoService);
+
+  enableNotifications(): void {
+    void this.notificationService.requestPermission();
+  }
 }

--- a/src/app/models/todo.ts
+++ b/src/app/models/todo.ts
@@ -1,0 +1,6 @@
+export interface Todo {
+  id: string;
+  title: string;
+  completed: boolean;
+  updatedAt: number;
+}

--- a/src/app/services/connectivity.service.ts
+++ b/src/app/services/connectivity.service.ts
@@ -1,0 +1,37 @@
+import { DestroyRef, Injectable, NgZone, computed, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { fromEvent, merge, of } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+@Injectable({ providedIn: 'root' })
+export class ConnectivityService {
+  private readonly online = signal<boolean>(this.getInitialStatus());
+
+  readonly isOnline = computed(() => this.online());
+
+  constructor(private readonly zone: NgZone, private readonly destroyRef: DestroyRef) {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    merge(
+      of(this.getInitialStatus()),
+      fromEvent(window, 'online', { passive: true }).pipe(map(() => true)),
+      fromEvent(window, 'offline', { passive: true }).pipe(map(() => false))
+    )
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((status) => this.updateStatus(status));
+  }
+
+  private updateStatus(status: boolean): void {
+    this.zone.run(() => this.online.set(status));
+  }
+
+  private getInitialStatus(): boolean {
+    if (typeof navigator === 'undefined') {
+      return true;
+    }
+
+    return navigator.onLine;
+  }
+}

--- a/src/app/services/notification.service.ts
+++ b/src/app/services/notification.service.ts
@@ -1,0 +1,54 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class NotificationService {
+  private permission: NotificationPermission | null = this.initialPermission();
+
+  async requestPermission(): Promise<NotificationPermission> {
+    if (!this.isNotificationSupported()) {
+      return 'denied';
+    }
+
+    if (!this.permission || this.permission === 'default') {
+      this.permission = await Notification.requestPermission();
+    }
+
+    return this.permission;
+  }
+
+  async notify(title: string, options?: NotificationOptions): Promise<void> {
+    if (!this.isNotificationSupported()) {
+      return;
+    }
+
+    const permission = await this.requestPermission();
+    if (permission !== 'granted') {
+      return;
+    }
+
+    try {
+      const registration = await navigator.serviceWorker?.ready;
+      if (registration) {
+        await registration.showNotification(title, options);
+        return;
+      }
+    } catch (error) {
+      console.error('Unable to use service worker for notification', error);
+    }
+
+    // Fallback to direct notification if service worker registration is unavailable
+    new Notification(title, options);
+  }
+
+  private isNotificationSupported(): boolean {
+    return typeof window !== 'undefined' && 'Notification' in window;
+  }
+
+  private initialPermission(): NotificationPermission | null {
+    if (!this.isNotificationSupported()) {
+      return null;
+    }
+
+    return Notification.permission;
+  }
+}

--- a/src/app/services/todo-storage.service.ts
+++ b/src/app/services/todo-storage.service.ts
@@ -1,0 +1,52 @@
+import { Injectable } from '@angular/core';
+import { openDB, type IDBPDatabase } from 'idb';
+import type { Todo } from '../models/todo';
+
+const DATABASE_NAME = 'todo-store';
+const STORE_NAME = 'data';
+const TODOS_KEY = 'todos';
+
+@Injectable({ providedIn: 'root' })
+export class TodoStorageService {
+  private dbPromise: Promise<IDBPDatabase> | null = null;
+  private readonly supportsIndexedDb = typeof indexedDB !== 'undefined';
+  private inMemoryCache: Todo[] = [];
+
+  async loadTodos(): Promise<Todo[]> {
+    if (!this.supportsIndexedDb) {
+      return this.inMemoryCache;
+    }
+
+    const db = await this.getDatabase();
+    const stored = await db.get(STORE_NAME, TODOS_KEY);
+    return Array.isArray(stored) ? stored : [];
+  }
+
+  async saveTodos(todos: Todo[]): Promise<void> {
+    if (!this.supportsIndexedDb) {
+      this.inMemoryCache = todos;
+      return;
+    }
+
+    const db = await this.getDatabase();
+    await db.put(STORE_NAME, todos, TODOS_KEY);
+  }
+
+  private getDatabase(): Promise<IDBPDatabase> {
+    if (!this.supportsIndexedDb) {
+      return Promise.reject(new Error('IndexedDB is not supported in this environment.'));
+    }
+
+    if (!this.dbPromise) {
+      this.dbPromise = openDB(DATABASE_NAME, 1, {
+        upgrade(database) {
+          if (!database.objectStoreNames.contains(STORE_NAME)) {
+            database.createObjectStore(STORE_NAME);
+          }
+        }
+      });
+    }
+
+    return this.dbPromise;
+  }
+}

--- a/src/app/services/todo.service.ts
+++ b/src/app/services/todo.service.ts
@@ -1,0 +1,110 @@
+import { Injectable, effect, inject, signal } from '@angular/core';
+import { Todo } from '../models/todo';
+import { TodoStorageService } from './todo-storage.service';
+import { NotificationService } from './notification.service';
+
+@Injectable({ providedIn: 'root' })
+export class TodoService {
+  private readonly storage = inject(TodoStorageService);
+  private readonly notifications = inject(NotificationService);
+
+  private readonly todos = signal<Todo[]>([]);
+  private readonly initialized = signal(false);
+
+  readonly all = this.todos.asReadonly();
+
+  constructor() {
+    void this.restoreTodos();
+
+    effect(() => {
+      if (this.initialized()) {
+        void this.storage.saveTodos(this.todos()).catch((error) =>
+          console.error('Failed to persist todos', error)
+        );
+      }
+    });
+  }
+
+  addTodo(title: string): void {
+    const trimmed = title.trim();
+    if (!trimmed) {
+      return;
+    }
+
+    const now = Date.now();
+    const todo: Todo = {
+      id: this.generateId(),
+      title: trimmed,
+      completed: false,
+      updatedAt: now
+    };
+
+    this.todos.update((current) => [todo, ...current]);
+    void this.notifications
+      .notify('Todo added', {
+        body: `“${trimmed}” was added to your list.`,
+        tag: todo.id
+      })
+      .catch((error) => console.error('Failed to send add notification', error));
+  }
+
+  toggleTodo(id: string, completed: boolean): void {
+    this.todos.update((current) =>
+      current.map((todo) =>
+        todo.id === id ? { ...todo, completed, updatedAt: Date.now() } : todo
+      )
+    );
+  }
+
+  updateTodoTitle(id: string, title: string): void {
+    const trimmed = title.trim();
+    if (!trimmed) {
+      this.removeTodo(id);
+      return;
+    }
+
+    this.todos.update((current) =>
+      current.map((todo) =>
+        todo.id === id ? { ...todo, title: trimmed, updatedAt: Date.now() } : todo
+      )
+    );
+
+    const updatedTodo = this.todos().find((todo) => todo.id === id);
+    if (updatedTodo) {
+      void this.notifications
+        .notify('Todo updated', {
+          body: `“${updatedTodo.title}” was updated.`,
+          tag: updatedTodo.id
+        })
+        .catch((error) => console.error('Failed to send update notification', error));
+    }
+  }
+
+  removeTodo(id: string): void {
+    this.todos.update((current) => current.filter((todo) => todo.id !== id));
+  }
+
+  trackById(_: number, todo: Todo): string {
+    return todo.id;
+  }
+
+  private async restoreTodos(): Promise<void> {
+    try {
+      const stored = await this.storage.loadTodos();
+      this.todos.set(stored);
+    } catch (error) {
+      console.error('Failed to restore todos from storage', error);
+      this.todos.set([]);
+    } finally {
+      this.initialized.set(true);
+    }
+  }
+
+  private generateId(): string {
+    if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+      return crypto.randomUUID();
+    }
+
+    return Math.random().toString(36).slice(2, 11);
+  }
+}


### PR DESCRIPTION
## Summary
- replace the placeholder view with an offline-ready todo planner UI that supports creating, editing, completing, and deleting tasks
- persist todos with IndexedDB-backed storage and surface connectivity status alongside a refreshed PWA manifest
- add browser notification plumbing to alert when todos are added or updated and request permissions from the UI

## Testing
- `npm run build`
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: Chrome binary unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d52ceee06c8326a94d1c8b20711759