### PR TITLE
feat: add offline support and refreshed todo UI

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -2,7 +2,8 @@
   "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
   "version": 1,
   "cli": {
-    "packageManager": "npm"
+    "packageManager": "npm",
+    "analytics": false
   },
   "newProjectRoot": "projects",
   "projects": {

--- a/server/server.js
+++ b/server/server.js
@@ -28,10 +28,10 @@ let todos = [
 app.get('/api/todos', (_req, res) => res.json(todos));
 
 app.post('/api/todos', (req, res) => {
-  const { title } = req.body || {};
+  const { title, done = false } = req.body || {};
   if (!title) return res.status(400).json({ message: 'title is required' });
   const id = todos.length ? Math.max(...todos.map((t) => t.id)) + 1 : 1;
-  const newTodo = { id, title, done: false };
+  const newTodo = { id, title, done: Boolean(done) };
   todos.push(newTodo);
   res.status(201).json(newTodo);
 });
@@ -42,7 +42,7 @@ app.patch('/api/todos/:id', (req, res) => {
   if (!todo) return res.status(404).json({ message: 'todo not found' });
   const { title, done } = req.body || {};
   if (title !== undefined) todo.title = title;
-  if (done !== undefined) todo.done = done;
+  if (done !== undefined) todo.done = Boolean(done);
   res.json(todo);
 });
 

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -1,1 +1,3 @@
-<router-outlet></router-outlet>
+<main class="app-shell">
+  <router-outlet></router-outlet>
+</main>

--- a/src/app/app.scss
+++ b/src/app/app.scss
@@ -1,0 +1,10 @@
+.app-shell {
+  width: min(960px, 100%);
+  padding: 3rem 1rem 4rem;
+}
+
+@media (max-width: 600px) {
+  .app-shell {
+    padding: 2rem 0.75rem 3rem;
+  }
+}

--- a/src/app/core/api.ts
+++ b/src/app/core/api.ts
@@ -1,31 +1,341 @@
 import { HttpClient } from '@angular/common/http';
-import { inject, Injectable, signal } from '@angular/core';
+import { inject, Injectable, computed, signal } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+import { OfflineService } from './offline.service';
 
 export interface Todo {
   id: number;
   title: string;
   done: boolean;
 }
+
+type PendingAction =
+  | { type: 'add'; tempId: number; title: string; done: boolean }
+  | { type: 'toggle'; id: number; done: boolean }
+  | { type: 'delete'; id: number };
+
+const TODOS_CACHE_KEY = 'pwa-demo.todos';
+const QUEUE_CACHE_KEY = 'pwa-demo.queue';
+
 @Injectable({
   providedIn: 'root',
 })
 export class Api {
   private http = inject(HttpClient);
+  private offline = inject(OfflineService);
 
   todos = signal<Todo[]>([]);
+  readonly pendingCount = computed(() => this.pendingActions().length);
+
+  private readonly pendingActions = signal<PendingAction[]>([]);
+  private syncing = false;
+
+  constructor() {
+    this.restoreFromStorage();
+    this.offline.onOnline(() => this.syncPending());
+  }
 
   async loadTodos() {
-    const data = await this.http.get<Todo[]>('/api/todos').toPromise();
-    this.todos.set(data ?? []);
+    if (!this.offline.isBrowser) {
+      return;
+    }
+
+    if (!this.offline.isOnline()) {
+      this.todos.set(this.todos());
+      return;
+    }
+
+    try {
+      const data = await firstValueFrom(this.http.get<Todo[]>('/api/todos'));
+      if (data) {
+        this.todos.set(data);
+        this.persistTodos();
+      }
+    } catch (error) {
+      console.error('Failed to load todos', error);
+    } finally {
+      this.syncPending();
+    }
   }
 
-  async addTodo(title: string) {
-    const newTodo = await this.http.post<Todo>('/api/todos', { title }).toPromise();
-    this.todos.update((todos) => [...todos, newTodo!]);
+  async addTodo(title: string): Promise<Todo | undefined> {
+    const trimmed = title.trim();
+    if (!trimmed) {
+      return;
+    }
+
+    if (!this.offline.isOnline()) {
+      const tempId = -Date.now();
+      const offlineTodo: Todo = { id: tempId, title: trimmed, done: false };
+      this.todos.update((todos) => [...todos, offlineTodo]);
+      this.persistTodos();
+      this.queueAction({ type: 'add', tempId, title: trimmed, done: false });
+      this.offline.notify('Saved offline', {
+        body: 'New todo will sync when you are back online.',
+      });
+      return offlineTodo;
+    }
+
+    try {
+      const created = await this.createRemoteTodo(trimmed);
+      if (created) {
+        this.todos.update((todos) => [...todos, created]);
+        this.persistTodos();
+        this.offline.notify('Todo added', {
+          body: 'Task saved to the server.',
+        });
+      }
+      return created;
+    } catch (error) {
+      console.error('Failed to create todo', error);
+    }
+
+    return undefined;
   }
 
-  async toggleTodo(id: number, done: boolean) {
-    const updatedTodo = await this.http.patch<Todo>(`/api/todos/${id}`, { done }).toPromise();
-    this.todos.update((todos) => todos.map((t) => (t.id === id ? updatedTodo! : t)));
+  async toggleTodo(todo: Todo, done: boolean): Promise<Todo | undefined> {
+    const updated: Todo = { ...todo, done };
+    this.todos.update((todos) => todos.map((t) => (t.id === todo.id ? updated : t)));
+    this.persistTodos();
+
+    if (!this.offline.isOnline()) {
+      if (todo.id < 0) {
+        this.queueAction({ type: 'add', tempId: todo.id, title: todo.title, done });
+      } else {
+        this.queueAction({ type: 'toggle', id: todo.id, done });
+      }
+      this.offline.notify('Saved offline', {
+        body: 'Changes will sync once you are online.',
+      });
+      return updated;
+    }
+
+    try {
+      const serverTodo = await this.updateRemoteTodo(todo.id, done);
+      if (serverTodo) {
+        this.todos.update((todos) => todos.map((t) => (t.id === todo.id ? serverTodo : t)));
+        this.persistTodos();
+      }
+      return serverTodo;
+    } catch (error) {
+      console.error('Failed to update todo', error);
+    }
+
+    return undefined;
+  }
+
+  async deleteTodo(todo: Todo): Promise<boolean> {
+    const previous = this.todos();
+    this.todos.update((todos) => todos.filter((t) => t.id !== todo.id));
+    this.persistTodos();
+
+    if (!this.offline.isOnline()) {
+      this.removeQueuedFor(todo.id);
+
+      if (todo.id >= 0) {
+        this.queueAction({ type: 'delete', id: todo.id });
+        this.offline.notify('Saved offline', {
+          body: 'Todo will be deleted when you are back online.',
+        });
+      } else {
+        this.offline.notify('Removed', {
+          body: 'Unsynced todo discarded.',
+        });
+      }
+
+      return true;
+    }
+
+    try {
+      await this.deleteRemoteTodo(todo.id);
+      this.offline.notify('Todo deleted', {
+        body: 'Task removed from the server.',
+      });
+      return true;
+    } catch (error) {
+      console.error('Failed to delete todo', error);
+      this.todos.set(previous);
+      this.persistTodos();
+    }
+
+    return false;
+  }
+
+  private async createRemoteTodo(title: string) {
+    return firstValueFrom(this.http.post<Todo>('/api/todos', { title }));
+  }
+
+  private async updateRemoteTodo(id: number, done: boolean) {
+    return firstValueFrom(this.http.patch<Todo>(`/api/todos/${id}`, { done }));
+  }
+
+  private async deleteRemoteTodo(id: number) {
+    try {
+      await firstValueFrom(this.http.delete<void>(`/api/todos/${id}`));
+    } catch (error: any) {
+      if (error?.status === 404) {
+        return;
+      }
+      throw error;
+    }
+  }
+
+  private restoreFromStorage() {
+    if (!this.offline.isBrowser) {
+      return;
+    }
+
+    try {
+      const savedTodos = localStorage.getItem(TODOS_CACHE_KEY);
+      if (savedTodos) {
+        this.todos.set(JSON.parse(savedTodos));
+      }
+
+      const queue = localStorage.getItem(QUEUE_CACHE_KEY);
+      if (queue) {
+        this.pendingActions.set(JSON.parse(queue));
+      }
+    } catch (error) {
+      console.error('Failed to restore cached data', error);
+    }
+  }
+
+  private persistTodos() {
+    if (!this.offline.isBrowser) {
+      return;
+    }
+    try {
+      localStorage.setItem(TODOS_CACHE_KEY, JSON.stringify(this.todos()));
+    } catch (error) {
+      console.error('Failed to persist todos', error);
+    }
+  }
+
+  private persistQueue() {
+    if (!this.offline.isBrowser) {
+      return;
+    }
+    try {
+      localStorage.setItem(QUEUE_CACHE_KEY, JSON.stringify(this.pendingActions()));
+    } catch (error) {
+      console.error('Failed to persist queue', error);
+    }
+  }
+
+  private queueAction(action: PendingAction) {
+    this.updatePendingActions((current) => {
+      if (action.type === 'toggle') {
+        const existingIndex = current.findIndex((item) => item.type === 'toggle' && item.id === action.id);
+        if (existingIndex >= 0) {
+          current[existingIndex] = action;
+        } else {
+          current.push(action);
+        }
+        return current;
+      }
+
+      if (action.type === 'add') {
+        const existingIndex = current.findIndex((item) => item.type === 'add' && item.tempId === action.tempId);
+        if (existingIndex >= 0) {
+          current[existingIndex] = action;
+        } else {
+          current.push(action);
+        }
+        return current;
+      }
+
+      const filtered = current.filter((item) => {
+        if (item.type === 'delete' && item.id === action.id) {
+          return false;
+        }
+        if (item.type === 'toggle' && item.id === action.id) {
+          return false;
+        }
+        if (item.type === 'add' && item.tempId === action.id) {
+          return false;
+        }
+        return true;
+      });
+      filtered.push(action);
+      return filtered;
+    });
+  }
+
+  private replaceTodo(oldId: number, todo: Todo) {
+    this.todos.update((todos) => todos.map((t) => (t.id === oldId ? todo : t)));
+    this.persistTodos();
+  }
+
+  private removeQueuedFor(id: number) {
+    this.updatePendingActions((current) =>
+      current.filter((action) => {
+        if (action.type === 'add' && action.tempId === id) {
+          return false;
+        }
+        if (action.type === 'toggle' && action.id === id) {
+          return false;
+        }
+        if (action.type === 'delete' && action.id === id) {
+          return false;
+        }
+        return true;
+      })
+    );
+  }
+
+  private updatePendingActions(updater: (current: PendingAction[]) => PendingAction[]) {
+    const updated = updater([...this.pendingActions()]);
+    this.pendingActions.set(updated);
+    this.persistQueue();
+    return updated;
+  }
+
+  private async syncPending() {
+    if (this.syncing || !this.offline.isOnline() || this.pendingActions().length === 0) {
+      return;
+    }
+
+    this.syncing = true;
+
+    try {
+      const queue = [...this.pendingActions()];
+      const remaining: PendingAction[] = [];
+
+      for (let i = 0; i < queue.length; i++) {
+        const action = queue[i];
+        try {
+          if (action.type === 'add') {
+            let synced = await this.createRemoteTodo(action.title);
+            if (synced && action.done !== synced.done) {
+              synced = await this.updateRemoteTodo(synced.id, action.done);
+            }
+            if (synced) {
+              this.replaceTodo(action.tempId, synced);
+            }
+          } else if (action.type === 'toggle') {
+            const synced = await this.updateRemoteTodo(action.id, action.done);
+            if (synced) {
+              this.replaceTodo(action.id, synced);
+            }
+          } else {
+            await this.deleteRemoteTodo(action.id);
+          }
+        } catch (error) {
+          console.error('Failed to sync action', action, error);
+          remaining.push(action, ...queue.slice(i + 1));
+          break;
+        }
+      }
+
+      this.pendingActions.set(remaining);
+      if (remaining.length === 0) {
+        this.offline.notify('Changes synced', {
+          body: 'Your offline changes were saved to the server.',
+        });
+      }
+    } finally {
+      this.persistQueue();
+      this.syncing = false;
+    }
   }
 }

--- a/src/app/core/offline.service.ts
+++ b/src/app/core/offline.service.ts
@@ -1,0 +1,99 @@
+import { Injectable, computed, inject, signal } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+import { PLATFORM_ID, NgZone } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class OfflineService {
+  private readonly platformId = inject(PLATFORM_ID);
+  private readonly zone = inject(NgZone);
+  readonly isBrowser = isPlatformBrowser(this.platformId);
+
+  private registration: ServiceWorkerRegistration | undefined;
+  private readonly onlineStatus = signal(this.isBrowser ? navigator.onLine : true);
+  private readonly onlineCallbacks = new Set<() => void>();
+
+  readonly isOnline = computed(() => this.onlineStatus());
+
+  constructor() {
+    if (!this.isBrowser) {
+      return;
+    }
+
+    this.zone.runOutsideAngular(() => {
+      window.addEventListener('online', this.handleOnlineChange);
+      window.addEventListener('offline', this.handleOnlineChange);
+    });
+
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.ready.then((reg) => {
+        this.registration = reg;
+      });
+    }
+
+    if ('Notification' in window && Notification.permission === 'default') {
+      Notification.requestPermission().catch(() => void 0);
+    }
+  }
+
+  onOnline(callback: () => void) {
+    this.onlineCallbacks.add(callback);
+  }
+
+  private handleOnlineChange = () => {
+    this.zone.run(() => {
+      const online = navigator.onLine;
+      const previous = this.onlineStatus();
+      this.onlineStatus.set(online);
+
+      if (online !== previous) {
+        if (online) {
+          this.notify('Back online', {
+            body: 'Your changes will sync automatically.',
+          });
+          this.onlineCallbacks.forEach((cb) => cb());
+        } else {
+          this.notify('Offline mode', {
+            body: 'You can keep working and your changes will sync later.',
+          });
+        }
+      }
+    });
+  };
+
+  async notify(title: string, options?: NotificationOptions) {
+    if (!this.isBrowser || !('Notification' in window)) {
+      return;
+    }
+
+    if (Notification.permission === 'default') {
+      try {
+        await Notification.requestPermission();
+      } catch {
+        // ignore
+      }
+    }
+
+    if (Notification.permission !== 'granted') {
+      return;
+    }
+
+    const payload: NotificationOptions = {
+      icon: '/icons/icon-192x192.png',
+      badge: '/icons/icon-96x96.png',
+      ...options,
+    };
+
+    if (this.registration && 'showNotification' in this.registration) {
+      try {
+        await this.registration.showNotification(title, payload);
+        return;
+      } catch {
+        // fall back to Notification constructor
+      }
+    }
+
+    new Notification(title, payload);
+  }
+}

--- a/src/app/features/todos.scss
+++ b/src/app/features/todos.scss
@@ -1,0 +1,255 @@
+.todos-page {
+  max-width: 520px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.hero {
+  text-align: center;
+
+  h1 {
+    font-size: clamp(1.75rem, 2.5vw, 2.5rem);
+    margin-bottom: 0.25rem;
+  }
+
+  p {
+    color: rgba(255, 255, 255, 0.75);
+    font-size: 0.95rem;
+  }
+}
+
+.status {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  background: rgba(76, 175, 80, 0.12);
+  border: 1px solid rgba(76, 175, 80, 0.35);
+  backdrop-filter: blur(6px);
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+
+  &.offline {
+    background: rgba(244, 67, 54, 0.12);
+    border-color: rgba(244, 67, 54, 0.45);
+
+    .indicator {
+      background: #f44336;
+      box-shadow: 0 0 0 4px rgba(244, 67, 54, 0.15);
+    }
+  }
+}
+
+.indicator {
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  background: #4caf50;
+  box-shadow: 0 0 0 4px rgba(76, 175, 80, 0.15);
+}
+
+.status-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  font-size: 0.9rem;
+
+  strong {
+    font-weight: 600;
+    font-size: 1rem;
+  }
+
+  span {
+    color: rgba(255, 255, 255, 0.7);
+  }
+}
+
+.pending {
+  margin-left: auto;
+  font-size: 0.85rem;
+  font-weight: 600;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(255, 215, 64, 0.15);
+  border: 1px solid rgba(255, 215, 64, 0.5);
+  color: #ffd740;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.card {
+  padding: 1.5rem;
+  border-radius: 1rem;
+  background: rgba(32, 35, 45, 0.85);
+  box-shadow: 0 24px 40px rgba(0, 0, 0, 0.25);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+form {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+
+  input {
+    flex: 1;
+    padding: 0.75rem 1rem;
+    border-radius: 0.75rem;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    background: rgba(12, 14, 20, 0.65);
+    color: inherit;
+    font-size: 1rem;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+
+    &:focus {
+      outline: none;
+      border-color: rgba(99, 102, 241, 0.65);
+      box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.35);
+    }
+
+    &::placeholder {
+      color: rgba(255, 255, 255, 0.45);
+    }
+  }
+
+  button {
+    padding: 0.75rem 1.5rem;
+    border: none;
+    border-radius: 0.75rem;
+    background: linear-gradient(135deg, #7c4dff, #3d5afe);
+    color: white;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.2s ease, opacity 0.2s ease;
+
+    &:hover:not(:disabled) {
+      transform: translateY(-1px);
+    }
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+  }
+}
+
+.todo-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin: 0;
+  padding: 0;
+
+  li {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.65rem 0.75rem;
+    border-radius: 0.75rem;
+    background: rgba(15, 17, 25, 0.65);
+    border: 1px solid transparent;
+    transition: border-color 0.2s ease, background-color 0.2s ease;
+
+    &.completed {
+      opacity: 0.65;
+      text-decoration: line-through;
+    }
+
+    label {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      flex: 1;
+
+      input[type='checkbox'] {
+        width: 20px;
+        height: 20px;
+        accent-color: #7c4dff;
+      }
+
+      span {
+        font-size: 0.95rem;
+      }
+    }
+
+    .icon-button {
+      border: none;
+      background: transparent;
+      color: rgba(255, 255, 255, 0.6);
+      width: 36px;
+      height: 36px;
+      border-radius: 0.65rem;
+      display: grid;
+      place-items: center;
+      font-size: 1.1rem;
+      cursor: pointer;
+      transition: color 0.2s ease, background-color 0.2s ease, transform 0.2s ease;
+
+      &:hover,
+      &:focus-visible {
+        color: #f87171;
+        background: rgba(248, 113, 113, 0.16);
+      }
+
+      &:focus-visible {
+        outline: 2px solid rgba(248, 113, 113, 0.45);
+        outline-offset: 2px;
+      }
+
+      &:active {
+        transform: scale(0.95);
+      }
+    }
+  }
+
+  .empty {
+    text-align: center;
+    color: rgba(255, 255, 255, 0.6);
+    font-style: italic;
+    padding: 1rem 0;
+    border: 1px dashed rgba(255, 255, 255, 0.2);
+  }
+}
+
+.badge {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+  background: rgba(99, 102, 241, 0.2);
+  border: 1px solid rgba(99, 102, 241, 0.5);
+  color: #a5b4fc;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+@media (max-width: 600px) {
+  .todos-page {
+    padding: 1.5rem 1rem 2rem;
+  }
+
+  form {
+    flex-direction: column;
+    align-items: stretch;
+
+    button {
+      width: 100%;
+    }
+  }
+}

--- a/src/app/features/todos.ts
+++ b/src/app/features/todos.ts
@@ -2,33 +2,83 @@ import { Component, inject, PLATFORM_ID } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { Api, Todo } from '../core/api';
 import { isPlatformBrowser } from '@angular/common';
+import { OfflineService } from '../core/offline.service';
 @Component({
   selector: 'app-todos',
   imports: [FormsModule],
   template: `
-    <h1>Todos</h1>
-    <form (ngSubmit)="add()" #f="ngForm">
-      <input type="text" name="title" [(ngModel)]="title" placeholder="New todo" />
+    <div class="todos-page">
+      <header class="hero">
+        <h1>Task board</h1>
+        <p>Capture your todos and keep working offline.</p>
+      </header>
 
-      <button type="submit">Add</button>
-    </form>
+      <section class="status" [class.offline]="!offline.isOnline()">
+        <span class="indicator" aria-hidden="true"></span>
+        <div class="status-text">
+          <strong>{{ offline.isOnline() ? 'Online' : 'Offline' }}</strong>
+          <span>
+            {{
+              offline.isOnline()
+                ? 'Connected to the server'
+                : 'Changes are stored locally and will sync later'
+            }}
+          </span>
+        </div>
+        @if (api.pendingCount()) {
+        <span class="pending">{{ api.pendingCount() }} pending</span>
+        }
+      </section>
 
-    <ul>
-      @for (todo of api.todos(); track todo.id) {
-      <li>
-        <label>
-          <input type="checkbox" (change)="toggle(todo)" [checked]="todo.done" />
-          {{ todo.title }}
-        </label>
-      </li>
-      }
-    </ul>
+      <section class="card">
+        <form (ngSubmit)="add()" novalidate>
+          <label class="sr-only" for="newTodo">Add todo</label>
+          <input
+            id="newTodo"
+            type="text"
+            name="title"
+            [(ngModel)]="title"
+            placeholder="What needs to be done?"
+            autocomplete="off"
+          />
+
+          <button type="submit" [disabled]="!title.trim()">Add</button>
+        </form>
+
+        <ul class="todo-list">
+          @if (api.todos().length === 0) {
+          <li class="empty">Nothing here yet. Add your first todo!</li>
+          } @else {
+          @for (todo of api.todos(); track todo.id) {
+          <li [class.completed]="todo.done">
+            <label>
+              <input type="checkbox" (change)="toggle(todo)" [checked]="todo.done" />
+              <span>{{ todo.title }}</span>
+            </label>
+            @if (todo.id < 0) {
+            <span class="badge">offline</span>
+            }
+            <button
+              type="button"
+              class="icon-button"
+              (click)="remove(todo, $event)"
+              [attr.aria-label]="'Delete ' + todo.title"
+            >
+              ✕
+            </button>
+          </li>
+          }
+          }
+        </ul>
+      </section>
+    </div>
   `,
   styleUrl: './todos.scss',
 })
 export class Todos {
   api = inject(Api);
   platformId = inject(PLATFORM_ID);
+  protected offline = inject(OfflineService);
   title = '';
 
   constructor() {
@@ -43,6 +93,12 @@ export class Todos {
   }
 
   async toggle(todo: Todo) {
-    await this.api.toggleTodo(todo.id, !todo.done);
+    await this.api.toggleTodo(todo, !todo.done);
+  }
+
+  async remove(todo: Todo, event?: Event) {
+    event?.preventDefault();
+    event?.stopPropagation();
+    await this.api.deleteTodo(todo);
   }
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,1 +1,35 @@
-/* You can add global styles to this file, and also import other style files */
+:root {
+  color-scheme: dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: radial-gradient(circle at top left, #1f2937, #0f172a 55%, #020617);
+  color: #f8fafc;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: stretch;
+  background: inherit;
+  color: inherit;
+}
+
+a {
+  color: inherit;
+}
+
+button,
+input,
+textarea,
+select {
+  font: inherit;
+}
+
+main {
+  width: 100%;
+}


### PR DESCRIPTION
## Summary
- add an offline service to track connectivity, show notifications, and coordinate queued syncs
- persist todos locally with queued mutations so the UI works fully offline and replays changes when online
- refresh the todos experience with an offline status banner, dark theme shell, and badge for unsynced items
- allow the API to accept an optional done flag while keeping server-side logic intact
- fix online add notifications and support deleting todos while preserving offline sync semantics

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d54e4773988326b649d848e08150fd